### PR TITLE
Fix CI build failure after Nuxt 3 upgrade

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Use Node.js 14.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@v4
       with:
-        node-version: '14.x'
+        node-version: '20.x'
 
-    - run: npm install
+    - run: npm install --legacy-peer-deps
     - run: npm run build --if-present
 #     - run: npm test
     - run: npm run generate
@@ -25,7 +25,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dist
+        publish_dir: ./.output/public
         cname: busy-praying.khatm.net
 #     - run: git clone --single-branch --branch gh-pages git@github.com:yusufhm/busy-praying.git /tmp/busy-praying-gh-pages
 #     - run: |


### PR DESCRIPTION
- Upgrade Node.js from 14.x to 20.x — Nuxt 3 requires Node >=18; the ||= operator used in @nuxt/cli is unsupported on Node 14
- Fix deploy publish_dir: Nuxt 3 generates to .output/public, not dist/
- Add --legacy-peer-deps to npm install to resolve peer dep conflicts
- Update actions/checkout v2->v4 and actions/setup-node v1->v4

https://claude.ai/code/session_016s4neRbDefA2PF9GRyzYDZ