### PR TITLE
Improve calendar mobile UX and fix timezone parsing issues

### DIFF
--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -3,8 +3,11 @@
     <v-col>
       <v-sheet height="64">
         <v-toolbar flat>
-          <v-btn variant="outlined" class="mr-4" color="grey-darken-2" @click="setToday">
+          <v-btn variant="outlined" class="mr-4 d-none d-sm-flex" color="grey-darken-2" @click="setToday">
             Today
+          </v-btn>
+          <v-btn icon size="small" variant="tonal" class="mr-2 d-flex d-sm-none" color="grey-darken-2" @click="setToday">
+            <v-icon>mdi-calendar-today</v-icon>
           </v-btn>
           <v-btn icon size="small" variant="text" color="grey-darken-2" @click="prev">
             <v-icon size="small">mdi-chevron-left</v-icon>
@@ -164,7 +167,11 @@ async function updateRange() {
     const date = day.date.readable
     for (const name of Object.keys(day.timings)) {
       if (SKIP_TIMINGS.has(name)) continue
-      const ts = Date.parse(`${date} ${day.timings[name]}`)
+      // Strip non-standard timezone suffix (e.g. " (IST)") that causes Date.parse
+      // to return NaN on many mobile browsers.
+      const timeStr = day.timings[name].replace(/\s*\(.*\)\s*$/, '')
+      const ts = Date.parse(`${date} ${timeStr}`)
+      if (isNaN(ts)) continue
       newEvents.push({
         title: name,
         start: new Date(ts),

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -37,7 +37,7 @@
         <v-calendar
           v-model="focus"
           :events="events"
-          :view-mode="type"
+          :type="type"
           @click:event="showEvent"
           @click:day="({ date }) => viewDay(date)"
           @update:model-value="updateRange"


### PR DESCRIPTION
## Summary
This PR improves the calendar component's mobile responsiveness and fixes timezone-related parsing issues that were causing events to fail loading on certain browsers.

## Key Changes
- **Mobile UI improvements**: Added a responsive "Today" button that shows as an icon on small screens and as a text button on larger screens using Vuetify's responsive display classes
- **Fixed timezone parsing**: Strip non-standard timezone suffixes (e.g., " (IST)") from timing strings before parsing, as these cause `Date.parse()` to return `NaN` on many mobile browsers
- **Added NaN validation**: Added a check to skip event creation if the timestamp parsing fails
- **Fixed prop name**: Changed `view-mode` to `type` prop on the v-calendar component to match the correct API

## Implementation Details
- The "Today" button now uses `d-none d-sm-flex` for the text variant (hidden on mobile, visible on small+ screens) and `d-flex d-sm-none` for the icon variant (visible on mobile, hidden on small+ screens)
- The timezone regex pattern `\s*\(.*\)\s*$` removes parenthetical timezone indicators that some APIs append to time strings
- The `isNaN(ts)` check prevents malformed events from being added to the calendar when parsing fails

https://claude.ai/code/session_012qKaBmNRHrZQW8h86kyZNE