### PR TITLE
Add theme preference system with light/dark/system modes

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app :theme="effectiveTheme">
     <v-app-bar app>
       <v-toolbar-title :text="title" />
       <v-spacer />
@@ -20,5 +20,32 @@
 </template>
 
 <script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useThemeStore } from '@/stores/theme'
+
 const title = 'Busy Praying'
+const themeStore = useThemeStore()
+const systemDark = ref(false)
+
+const effectiveTheme = computed(() =>
+  themeStore.preference === 'system'
+    ? (systemDark.value ? 'dark' : 'light')
+    : themeStore.preference
+)
+
+let mediaQuery = null
+
+function onSystemThemeChange(e) {
+  systemDark.value = e.matches
+}
+
+onMounted(() => {
+  mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  systemDark.value = mediaQuery.matches
+  mediaQuery.addEventListener('change', onSystemThemeChange)
+})
+
+onUnmounted(() => {
+  mediaQuery?.removeEventListener('change', onSystemThemeChange)
+})
 </script>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -1,4 +1,25 @@
 <template>
+  <div>
+  <v-card class="mb-6">
+    <v-card-title>Theme</v-card-title>
+    <v-card-text>
+      <v-btn-toggle v-model="themeStore.preference" mandatory color="primary">
+        <v-btn value="light">
+          <v-icon start>mdi-weather-sunny</v-icon>
+          Light
+        </v-btn>
+        <v-btn value="dark">
+          <v-icon start>mdi-weather-night</v-icon>
+          Dark
+        </v-btn>
+        <v-btn value="system">
+          <v-icon start>mdi-theme-light-dark</v-icon>
+          System
+        </v-btn>
+      </v-btn-toggle>
+    </v-card-text>
+  </v-card>
+
   <v-form ref="form" @submit.prevent="submit">
     <v-autocomplete
       v-model="country"
@@ -19,14 +40,17 @@
 
     <v-btn class="mr-4" type="submit">Save</v-btn>
   </v-form>
+  </div>
 </template>
 
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { Country, City } from 'country-state-city'
 import { usePrayertimesStore } from '@/stores/prayertimes'
+import { useThemeStore } from '@/stores/theme'
 
 const store = usePrayertimesStore()
+const themeStore = useThemeStore()
 const form = ref(null)
 const country = ref('')
 const city = ref('')

--- a/stores/theme.js
+++ b/stores/theme.js
@@ -1,0 +1,6 @@
+export const useThemeStore = defineStore('theme', {
+  state: () => ({
+    preference: 'light', // 'light' | 'dark' | 'system'
+  }),
+  persist: true,
+})


### PR DESCRIPTION
## Summary
This PR implements a theme preference system that allows users to choose between light, dark, or system-based themes. The theme preference is persisted and automatically applied across the application.

## Key Changes
- **New theme store** (`stores/theme.js`): Created a Pinia store to manage theme preference with persistence enabled
- **Default layout enhancement** (`layouts/default.vue`): 
  - Integrated theme store and system theme detection using `prefers-color-scheme` media query
  - Added computed property `effectiveTheme` that resolves the actual theme based on user preference
  - Bound the resolved theme to Vuetify's `v-app` component
  - Implemented lifecycle hooks to listen for system theme changes
- **Settings page** (`pages/settings.vue`):
  - Added theme preference selector with three options: Light, Dark, and System
  - Used Material Design Icons (mdi-weather-sunny, mdi-weather-night, mdi-theme-light-dark) for visual clarity
  - Integrated with the theme store for two-way binding

## Implementation Details
- System theme detection uses the native `window.matchMedia('(prefers-color-scheme: dark)')` API
- Theme preference is automatically persisted via the Pinia store's `persist` option
- The system theme listener is properly cleaned up on component unmount to prevent memory leaks
- When "system" preference is selected, the app dynamically responds to OS-level theme changes

https://claude.ai/code/session_01JpdCkFrfFQtCnen65KF8Ke