### PR TITLE
Add conditional navigation logic to home page continue button

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -19,11 +19,24 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn color="primary" to="/calendar">Continue</v-btn>
+          <v-btn color="primary" @click="handleContinue">Continue</v-btn>
         </v-card-actions>
       </v-card>
     </v-col>
   </v-row>
 </template>
 
-<script setup></script>
+<script setup>
+import { usePrayertimesStore } from '~/stores/prayertimes'
+
+const store = usePrayertimesStore()
+const router = useRouter()
+
+function handleContinue() {
+  if (store.city && store.country) {
+    router.push('/calendar')
+  } else {
+    router.push('/settings')
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
Updated the home page continue button to implement conditional navigation based on user settings. Instead of always navigating to the calendar, the app now checks if the user has configured their city and country before proceeding.

## Key Changes
- Changed the Continue button from a static route link (`to="/calendar"`) to a click handler (`@click="handleContinue"`)
- Added `handleContinue()` function that:
  - Checks if `city` and `country` are set in the prayertimes store
  - Navigates to `/calendar` if settings are configured
  - Redirects to `/settings` if settings are missing
- Imported `usePrayertimesStore` to access user configuration state
- Imported `useRouter` to enable programmatic navigation

## Implementation Details
The solution ensures users cannot skip the settings configuration step, improving the user experience by preventing navigation to the calendar view without required location data.

https://claude.ai/code/session_01KmQZd58TqaGQrbQmTDa6C1