### PR TITLE
Add consistent per-prayer colours with user-configurable colour picker

### DIFF
--- a/composables/useCalendarEvents.js
+++ b/composables/useCalendarEvents.js
@@ -1,10 +1,5 @@
 import { SYNC_TIMINGS } from '@/utils/prayerTimings'
-
-const COLORS = ['blue', 'indigo', 'deep-purple', 'cyan', 'green', 'orange', 'grey-darken-1']
-
-function rnd(a, b) {
-  return Math.floor((b - a + 1) * Math.random()) + a
-}
+import { DEFAULT_PRAYER_COLORS } from '@/stores/prayertimes'
 
 /**
  * Parse an ISO focus date string ("YYYY-MM-DD") into { year, month } using
@@ -29,8 +24,11 @@ export function parseFocusDate(focusStr) {
  *    "timedless" and falls back to event.timed for day-view positioning.
  *  - Timestamps are built from day.date.gregorian parts (not Date.parse on
  *    the human-readable string) for reliable cross-browser parsing.
+ *
+ * @param {Array} times - Array of day objects from the Al Adhan API.
+ * @param {Object} colors - Map of prayer name to hex color string.
  */
-export function buildCalendarEvents(times) {
+export function buildCalendarEvents(times, colors = DEFAULT_PRAYER_COLORS) {
   const events = []
   for (const day of times) {
     const gr = day.date.gregorian
@@ -48,7 +46,7 @@ export function buildCalendarEvents(times) {
         name,
         start: new Date(ts),
         end: new Date(ts + 30 * 60 * 1000),
-        color: COLORS[rnd(0, COLORS.length - 1)],
+        color: (colors ?? {})[name] ?? DEFAULT_PRAYER_COLORS[name] ?? '#607D8B',
         timed: true,
       })
     }

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -91,7 +91,13 @@ const typeToLabel = { month: 'Month', week: 'Week', day: 'Day' }
 const selectedEvent = ref({})
 const selectedElement = ref(null)
 const selectedOpen = ref(false)
-const events = ref([])
+
+const currentStart = computed(() => parseFocusDate(focus.value))
+const events = computed(() => {
+  const times = prayertimesStore.getTimes(currentStart.value)
+  if (!times.length) return []
+  return buildCalendarEvents(times, prayertimesStore.prayerColors)
+})
 
 const title = computed(() => {
   let d
@@ -164,14 +170,8 @@ function showEvent({ event, nativeEvent }) {
 
 async function updateRange() {
   const start = parseFocusDate(focus.value)
-
   calendarStore.setStartEnd({ start, end: start })
   await prayertimesStore.fetchTimes(start, $alAdhanFetchPrayerTimes)
-
-  const times = prayertimesStore.getTimes(start)
-  if (!times.length) return
-
-  events.value = buildCalendarEvents(times)
 }
 
 watch(focus, updateRange)

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -20,6 +20,52 @@
     </v-card-text>
   </v-card>
 
+  <v-card class="mb-6">
+    <v-card-title>Prayer Colours</v-card-title>
+    <v-card-text>
+      <v-row>
+        <v-col
+          v-for="prayer in prayers"
+          :key="prayer"
+          cols="12"
+          sm="6"
+          md="4"
+        >
+          <div class="d-flex align-center ga-3">
+            <span class="text-body-1">{{ prayer }}</span>
+            <v-btn
+              :color="store.prayerColors[prayer]"
+              size="small"
+              variant="flat"
+              rounded
+              @click="openColorPicker(prayer)"
+            >
+              <v-icon>mdi-palette</v-icon>
+            </v-btn>
+          </div>
+        </v-col>
+      </v-row>
+    </v-card-text>
+  </v-card>
+
+  <v-dialog v-model="colorPickerOpen" max-width="320">
+    <v-card>
+      <v-card-title>{{ editingPrayer }} Colour</v-card-title>
+      <v-card-text class="d-flex justify-center">
+        <v-color-picker
+          v-model="editingColor"
+          :modes="['hex']"
+          hide-inputs
+        ></v-color-picker>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn variant="text" @click="colorPickerOpen = false">Cancel</v-btn>
+        <v-btn color="primary" variant="text" @click="saveColor">Save</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
   <v-form ref="form" @submit.prevent="submit">
     <v-autocomplete
       v-model="country"
@@ -48,12 +94,30 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { Country, City } from 'country-state-city'
 import { usePrayertimesStore } from '@/stores/prayertimes'
 import { useThemeStore } from '@/stores/theme'
+import { SYNC_TIMINGS } from '@/utils/prayerTimings'
 
 const store = usePrayertimesStore()
 const themeStore = useThemeStore()
 const form = ref(null)
 const country = ref('')
 const city = ref('')
+
+const prayers = [...SYNC_TIMINGS]
+
+const colorPickerOpen = ref(false)
+const editingPrayer = ref('')
+const editingColor = ref('')
+
+function openColorPicker(prayer) {
+  editingPrayer.value = prayer
+  editingColor.value = store.prayerColors[prayer]
+  colorPickerOpen.value = true
+}
+
+function saveColor() {
+  store.setPrayerColor(editingPrayer.value, editingColor.value)
+  colorPickerOpen.value = false
+}
 
 const countries = computed(() =>
   Country.getAllCountries().map(({ name, isoCode }) => ({

--- a/stores/prayertimes.js
+++ b/stores/prayertimes.js
@@ -1,10 +1,19 @@
 import { defineStore } from 'pinia'
 
+export const DEFAULT_PRAYER_COLORS = {
+  Fajr: '#5C6BC0',
+  Dhuhr: '#FB8C00',
+  Asr: '#43A047',
+  Maghrib: '#E53935',
+  Isha: '#1565C0',
+}
+
 export const usePrayertimesStore = defineStore('prayertimes', {
   state: () => ({
     times: {},
     city: '',
     country: '',
+    prayerColors: { ...DEFAULT_PRAYER_COLORS },
   }),
 
   getters: {
@@ -23,6 +32,9 @@ export const usePrayertimesStore = defineStore('prayertimes', {
     },
     setCity(city) {
       this.city = city
+    },
+    setPrayerColor(prayer, color) {
+      this.prayerColors[prayer] = color
     },
     // fetchFn is passed in so the action is testable without Nuxt
     async fetchTimes(start, fetchFn) {


### PR DESCRIPTION
- Define default hex colours for each prayer (Fajr, Dhuhr, Asr, Maghrib, Isha) in prayertimes store instead of assigning random colours on every render
- buildCalendarEvents now accepts a colours map and uses per-prayer colours
- Calendar events are now a computed property that reactively rebuilds when colours change, removing the need to manually re-assign on fetch
- Settings page gains a "Prayer Colours" card where each prayer shows its current colour and opens a v-color-picker dialog to change it
- Colour preferences are persisted via the existing Pinia persist plugin

https://claude.ai/code/session_011VraEMNN3jyKe2ddDEkSxS